### PR TITLE
Handle null values for ansible_distribution and ansible_os_name

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -347,7 +347,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
           } else {
             StringBuilder sb = new StringBuilder();
 
-            if (root.has("ansible_distribution")) {
+            if (root.has("ansible_distribution") && !root.get("ansible_distribution").isJsonNull()) {
               sb.append(root.get("ansible_distribution").getAsString()).append(" ");
             }
             if (root.has("ansible_distribution_version")) {
@@ -366,7 +366,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
             node.setOsFamily(root.get("ansible_os_family").getAsString());
           }
 
-          if (root.has("ansible_os_name")) {
+          if (root.has("ansible_os_name") && !root.get("ansible_os_name").isJsonNull()) {
             node.setOsName(root.get("ansible_os_name").getAsString());
           }
 


### PR DESCRIPTION
Ansible made changes to their Windows setup module that sets these facts to `null` if the account connecting to a Windows node does not have administrative rights. The Rundeck Ansible plugin is not handling these `null` values properly.

Ansible Changes: [Here](https://github.com/ansible-collections/ansible.windows/pull/78)
The issue I submitted to Ansible where they explained the expected behavior: [Here](https://github.com/ansible-collections/ansible.windows/issues/389)

This PR should fix #311 