### PR TITLE
RSE-824: Fix: Error handler not working as expected with Ansible Node Step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ dependencies {
   pluginLibs 'com.google.code.gson:gson:2.10.1'
   implementation('org.rundeck:rundeck-core:4.16.0-rc1-20230815')
   implementation 'org.codehaus.groovy:groovy-all:3.0.9'
+
+  testImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
+  testImplementation "org.spockframework:spock-core"
+}
+
+tasks.withType(Test).configureEach {
+  useJUnitPlatform()
 }
 
 task copyToLib(type: Copy) {

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -96,12 +96,12 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
         } catch (AnsibleException e) {
             Map<String,Object> failureData = new HashMap<>();
             failureData.put("message",e.getMessage());
-            failureData.put("ansible-config", builder.getConfigFile());
+            failureData.put("ansible-config", configuration);
             throw new NodeStepException(e.getMessage(), e, e.getFailureReason(), failureData, e.getMessage());
         } catch (Exception e) {
             Map<String,Object> failureData = new HashMap<>();
             failureData.put("message",e.getMessage());
-            failureData.put("ansible-config", builder.getConfigFile());
+            failureData.put("ansible-config", configuration);
             throw new NodeStepException(e.getMessage(),e, AnsibleException.AnsibleFailureReason.AnsibleError, failureData, e.getMessage());
         }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -81,8 +81,7 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"False");
         }
 
-       AnsibleRunnerBuilder
-                builder = new AnsibleRunnerBuilder(context.getExecutionContext(), context.getFramework(), context.getNodes(), configuration);
+       AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(), context.getFramework(), context.getNodes(), configuration);
 
         try {
             runner = builder.buildAnsibleRunner();

--- a/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStepSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStepSpec.groovy
@@ -1,0 +1,47 @@
+package com.rundeck.plugins.ansible.plugin
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.common.INodeSet
+import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException
+import com.dtolabs.rundeck.plugins.step.NodeStepPlugin
+import com.dtolabs.rundeck.plugins.step.PluginStepContext
+import org.junit.jupiter.api.Assertions
+import spock.lang.Specification
+
+
+class AnsiblePlaybookInlineWorkflowNodeStepSpec extends Specification{
+
+    void "failure data should not include null values when throwing"(){
+        given:
+        NodeStepPlugin plugin = new AnsiblePlaybookInlineWorkflowNodeStep()
+        INodeEntry node = Mock(INodeEntry){
+            getNodename() >> 'localhost'
+        }
+
+        PluginStepContext context = Mock(PluginStepContext){
+            getDataContext() >> ['job': ['loglevel':'INFO']]
+            getExecutionContext() >> Mock(ExecutionContext){
+                getDataContext() >> [:]
+            }
+            getFramework() >> Mock(Framework)
+            getNodes() >> Mock(INodeSet){
+                getNodes() >> []
+            }
+        }
+
+        Map<String, Object> configuration = [
+                'ansible-playbook' : 'path/to/playbook'
+        ]
+
+        when:
+        plugin.executeNodeStep(context, configuration, node)
+
+        then:
+        NodeStepException e = thrown(NodeStepException)
+        e.getFailureData().each { String key, Object value ->
+            Assertions.assertNotNull(value, "Value for key ${key} should not be null")
+        }
+    }
+}


### PR DESCRIPTION
### Problem:
The ansible plugin is throwing a `NodeStepException` with a `failureData` map that has a `null` value in a field:
```
e.getFailureData() == [
"message" : "ERROR: Ansible execution returned with non zero code.",
"ansible-config" : null
]
```

This is happening because when building failure data in the plugin, it’s trying to use the` ansible-config-file-path` property which isn’t part of the `AnsiblePlaybookInlineWorkflowNodeStep` description.


##### This map must not have any null values because:
> When the step execution finishes, the context logger tries to create a map<String,String> with the mentioned result data by calling the toString() method on each value. This results in a NullPointerException which isn't catched by the BaseWorkflowExecutor (for not being a StepException) not adding this error to the step result, thus, not running the error handler.


#### Expected Outcome:
the ansible plugin should not return null values on the `StepException` failure data map and not use properties that are not part of the plugin description

### Proposed Solution:

Use the configuration map for the ansible-config field when an exception is cached in the plugin.