### PR TITLE
RUN-2130: print an error if the node doesn't have a hostname in generate inventory

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import com.google.gson.Gson;
+import groovy.lang.MissingPropertyException;
 
 public class AnsibleInventoryBuilder {
 
@@ -25,6 +26,9 @@ public class AnsibleInventoryBuilder {
             PrintWriter writer = new PrintWriter(file);
             AnsibleInventory ai = new AnsibleInventory();
             for (INodeEntry e : nodes) {
+                if( e.getHostname() == null ){
+                    throw new MissingPropertyException("No hostname for node: " + e.getNodename());
+                }
                 ai.addHost(e.getNodename(), e.getHostname(), new HashMap<String, String>(e.getAttributes()));
             }
             writer.write(new Gson().toJson(ai));

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
@@ -4,6 +4,7 @@ import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.HashMap;
@@ -27,14 +28,14 @@ public class AnsibleInventoryBuilder {
             AnsibleInventory ai = new AnsibleInventory();
             for (INodeEntry e : nodes) {
                 if( e.getHostname() == null ){
-                    throw new MissingPropertyException("No hostname for node: " + e.getNodename());
+                    throw new ConfigurationException("No hostname for node: " + e.getNodename());
                 }
                 ai.addHost(e.getNodename(), e.getHostname(), new HashMap<String, String>(e.getAttributes()));
             }
             writer.write(new Gson().toJson(ai));
             writer.close();
             return file;
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new ConfigurationException("Could not write temporary inventory: " + e.getMessage());
         }
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import com.google.gson.Gson;
-import groovy.lang.MissingPropertyException;
 
 public class AnsibleInventoryBuilder {
 


### PR DESCRIPTION
print an error if the node doesn't have a hostname set when the inventory is generated