### PR TITLE
RUN-2366: ENH - Added improvements

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -158,6 +158,8 @@ public interface AnsibleDescribable extends Describable {
 
     public static final String ANSIBLE_ENCRYPT_EXTRA_VARS = "ansible-encrypt-extra-vars";
 
+    String NUMBER_THREADS = "number-threads";
+
     public static Property PLAYBOOK_PATH_PROP = PropertyUtil.string(
     			ANSIBLE_PLAYBOOK_PATH,
               "Playbook",
@@ -526,5 +528,14 @@ public interface AnsibleDescribable extends Describable {
             .required(false)
             .title("Encrypt Extra Vars.")
             .description("Encrypt the value of the extra vars keys.")
+            .build();
+
+    Property NUMBER_THREADS_PROP = PropertyBuilder.builder()
+            .string(NUMBER_THREADS)
+            .required(false)
+            .title("Number of threads")
+            .description("Number of threads used to process nodes coming from Ansible. By default is 1.")
+            .renderingOption(StringRenderingConstants.GROUPING,"SECONDARY")
+            .renderingOption(StringRenderingConstants.GROUP_NAME,"Other")
             .build();
 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -361,6 +361,8 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
   @Override
   public INodeSet getNodes() throws ResourceModelSourceException {
 
+    long start = System.currentTimeMillis();
+    System.out.println("::> start Process...");
 
     NodeSetImpl nodes = new NodeSetImpl();
     final Gson gson = new Gson();
@@ -404,24 +406,17 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
 
     try {
       if (new File(tempDirectory.toFile(), "data").exists()) {
-        //DirectoryStream<Path> directoryStream = Files.newDirectoryStream(tempDirectory.resolve("data"));
 
         Stream<Path> directories = Files.list(tempDirectory.resolve("data"));
 
         ExecutorService executor = Executors.newFixedThreadPool(Integer.parseInt(numberThreads));
         System.out.println("::> Number of Threads: "+ numberThreads);
 
-        long start = System.currentTimeMillis();
-        System.out.println("::> start Process...");
-
         List<CompletableFuture<INodeEntry>> futures = directories
                 .map(factFile -> processFile(factFile, gson, executor))
                 .collect(Collectors.toList());
 
         futures.stream().map(CompletableFuture::join).forEach(nodes::putNode);
-
-        //directoryStream.close();
-
 
         long millisEnd = System.currentTimeMillis() - start;
         System.out.println("::> Millis: "+ millisEnd);

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -7,7 +7,6 @@ import com.dtolabs.rundeck.core.storage.StorageTree;
 import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree;
 import com.rundeck.plugins.ansible.ansible.AnsibleDescribable;
 import com.rundeck.plugins.ansible.ansible.AnsibleDescribable.AuthenticationType;
-import com.rundeck.plugins.ansible.ansible.AnsibleException;
 import com.rundeck.plugins.ansible.ansible.AnsibleRunner;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.INodeSet;
@@ -26,6 +25,8 @@ import com.google.gson.JsonPrimitive;
 import org.rundeck.app.spi.Services;
 import org.rundeck.storage.api.PathUtil;
 import org.rundeck.storage.api.StorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -37,14 +38,14 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRunnerPlugin {
+
+  static final Logger log = LoggerFactory.getLogger(AnsibleResourceModelSource.class);
 
   private Framework framework;
 
@@ -409,8 +410,8 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
 
         Stream<Path> directories = Files.list(tempDirectory.resolve("data"));
 
+        log.debug("Number of Threads: {}", numberThreads);
         ExecutorService executor = Executors.newFixedThreadPool(Integer.parseInt(numberThreads));
-        System.out.println("::> Number of Threads: "+ numberThreads);
 
         List<CompletableFuture<INodeEntry>> futures = directories
                 .map(factFile -> processFile(factFile, gson, executor))

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -104,6 +104,8 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
 
   protected boolean encryptExtraVars = false;
 
+  protected String numberThreads;
+
 
   public AnsibleResourceModelSource(final Framework framework) {
       this.framework = framework;
@@ -204,6 +206,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
 
     encryptExtraVars = "true".equals(resolveProperty(AnsibleDescribable.ANSIBLE_ENCRYPT_EXTRA_VARS,"false",configuration,executionDataContext));
 
+    numberThreads = resolveProperty(AnsibleDescribable.NUMBER_THREADS, "1", configuration, executionDataContext);
   }
 
   public AnsibleRunner.AnsibleRunnerBuilder buildAnsibleRunner() throws ResourceModelSourceException{

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceFactory.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceFactory.java
@@ -74,6 +74,8 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
 
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
 
+        builder.property(NUMBER_THREADS_PROP);
+
         DESC=builder.build();
     }
 

--- a/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
@@ -1,0 +1,40 @@
+package com.rundeck.plugins.ansible.plugin
+
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.common.NodeEntryImpl
+import com.dtolabs.rundeck.core.common.NodeSetImpl
+import com.dtolabs.rundeck.core.resources.ResourceModelSource
+import spock.lang.Specification
+
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.stream.Stream
+
+class AnsibleResourceModelSourceSpec extends Specification {
+
+    void "process node files"() {
+        given:
+        String nodeName = "localhost"
+        NodeSetImpl nodes = new NodeSetImpl()
+        INodeEntry entryNode = new NodeEntryImpl();
+        entryNode.nodename = nodeName
+        Stream<Path> directories = Stream.of(Path.of("/dir/file"))
+        CompletableFuture<INodeEntry> future = CompletableFuture.completedFuture(entryNode)
+        ResourceModelSource plugin = Spy(AnsibleResourceModelSource) {
+            1 * processFile(*_) >> future
+        }
+        plugin.numberThreads = 1
+
+        when:
+        plugin.executeFutures(directories, nodes)
+
+        then:
+        future.get()
+
+        then:
+        nodes.size() == 1
+        nodes[0].nodename == nodeName
+    }
+}
+
+


### PR DESCRIPTION
## ⛔️ Ticket
https://pagerduty.atlassian.net/browse/RPL-2

## ❌ Issue
The task of bringing and processing Ansible nodes requires too much processing, sometimes it takes more than 40 minutes with 4600 nodes.

## ✅ Description
When the Ansible nodes arrive to be transformed into nodes that Rundeck can manage, they will be processed asynchronously to be able to work with several at the same time and thus make the entire process faster.