### PR TITLE
RUN-3236: Error when running ansible plugin with encrypt extra vars

### DIFF
--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -112,12 +112,14 @@ class AnsibleRunnerSpec extends Specification{
     }
 
 
-    def "test clean temporary directory"(){
+    def "test clean temporary directory"() {
         given:
         def tmpDirectory = File.createTempDir("ansible-runner-test-", "tmp")
         String playbook = "test"
         String privateKey = "privateKey"
-        String extraVars = "test: 123\ntest2: 456"
+
+        // IMPORTANT: At least one valid extra var so encryptVariable() is called
+        String extraVars = "test: 123\ntest2: "  // test2 empty, test valid
 
         def runner = AnsibleRunner.playbookInline(playbook)
         runner.encryptExtraVars(true)
@@ -126,25 +128,25 @@ class AnsibleRunnerSpec extends Specification{
         runner.extraVars(extraVars)
         runner.customTmpDirPath("/tmp")
 
-        def process = Mock(Process){
+        def process = Mock(Process) {
             waitFor() >> 0
-            getInputStream()>> new ByteArrayInputStream("".getBytes())
+            getInputStream() >> new ByteArrayInputStream("".getBytes())
             getOutputStream() >> new ByteArrayOutputStream()
             getErrorStream() >> new ByteArrayInputStream("".getBytes())
         }
 
-        def processExecutor = Mock(ProcessExecutor){
-            run()>>process
+        def processExecutor = Mock(ProcessExecutor) {
+            run() >> process
         }
 
-        def processBuilder = Mock(ProcessExecutor.ProcessExecutorBuilder){
+        def processBuilder = Mock(ProcessExecutor.ProcessExecutorBuilder) {
             build() >> processExecutor
         }
 
-        def ansibleVault = Mock(AnsibleVault){
+        def ansibleVault = Mock(AnsibleVault) {
             checkAnsibleVault() >> true
             getVaultPasswordScriptFile() >> new File("vault-script-client.py")
-            encryptVariable(_,_) >> { throw new Exception("Error encrypting value") }
+            encryptVariable(_ as String, _ as String) >> { throw new Exception("Error encrypting value") }  // should be called for "test"
         }
 
         runner.processExecutorBuilder(processBuilder)
@@ -155,43 +157,44 @@ class AnsibleRunnerSpec extends Specification{
 
         then:
         def e = thrown(Exception)
-        e.message.contains("cannot parse extra var values")
+        e.message.contains("cannot encrypt extra var values")  // <--- updated message (your new function throws "cannot encrypt")
 
         !tmpDirectory.exists()
     }
 
-    def "test clean temporary files when a exception is trigger"(){
-        given:
 
+    def "test clean temporary files when a exception is trigger"() {
+        given:
         String playbook = "test"
         String privateKey = "privateKey"
-        String extraVars = "test: 123\ntest2: 456"
+
+        // IMPORTANT: At least one valid extra var so encryptVariable() is called
+        String extraVars = "test: 123\ntest2: "  // test2 empty, test valid
 
         def runnerBuilder = AnsibleRunner.playbookInline(playbook)
         runnerBuilder.encryptExtraVars(true)
         runnerBuilder.sshPrivateKey(privateKey)
         runnerBuilder.extraVars(extraVars)
 
-        def process = Mock(Process){
+        def process = Mock(Process) {
             waitFor() >> 0
-            getInputStream()>> new ByteArrayInputStream("".getBytes())
+            getInputStream() >> new ByteArrayInputStream("".getBytes())
             getOutputStream() >> new ByteArrayOutputStream()
             getErrorStream() >> new ByteArrayInputStream("".getBytes())
         }
 
-        def processExecutor = Mock(ProcessExecutor){
-            run()>>process
+        def processExecutor = Mock(ProcessExecutor) {
+            run() >> process
         }
 
-        def processBuilder = Mock(ProcessExecutor.ProcessExecutorBuilder){
+        def processBuilder = Mock(ProcessExecutor.ProcessExecutorBuilder) {
             build() >> processExecutor
         }
 
-
-        def ansibleVault = Mock(AnsibleVault){
+        def ansibleVault = Mock(AnsibleVault) {
             checkAnsibleVault() >> true
             getVaultPasswordScriptFile() >> new File("vault-script-client.py")
-            encryptVariable(_,_) >> { throw new Exception("Error encrypting value") }
+            encryptVariable(_ as String, _ as String) >> { throw new Exception("Error encrypting value") }  // should be called for "test"
         }
 
         runnerBuilder.processExecutorBuilder(processBuilder)
@@ -204,12 +207,11 @@ class AnsibleRunnerSpec extends Specification{
 
         then:
         def e = thrown(Exception)
-        e.message.contains("cannot parse extra var values")
+        e.message.contains("cannot encrypt extra var values")  // <--- updated message
 
         !runner.getTempPlaybook().exists()
-
-
     }
+
 
     def "test clean temporary files when process finished"(){
         given:


### PR DESCRIPTION
## Jira Ticket: https://pagerduty.atlassian.net/browse/RUN-3236

This pull request refines the `encryptExtraVarsKey` method in `AnsibleRunner.java` to improve error handling, validation, and handling of empty extra variables. Additionally, it updates and expands the test suite in `AnsibleRunnerSpec.groovy` to ensure the new functionality is thoroughly tested.

### Updates to `encryptExtraVarsKey` Method:

* **Improved Parsing Logic**: Added fallback parsing from YAML to JSON and enhanced error handling for invalid extra variables.
* **Validation Enhancements**: Introduced checks to ensure parsed extra variables are non-empty and valid, throwing specific exceptions when validation fails.
* **Skip Empty Values**: Added logic to skip null or empty extra variable values during encryption.

### Updates to Test Suite:

* **Updated Exception Messages**: Adjusted test cases to reflect the updated exception messages for encryption errors. [[1]](diffhunk://#diff-a30e3bcd92ebd10fe7a4f4d38eb2cbe3fcec38c7bd8b9b077b5a3253dd251f1aL120-R122) [[2]](diffhunk://#diff-a30e3bcd92ebd10fe7a4f4d38eb2cbe3fcec38c7bd8b9b077b5a3253dd251f1aL147-R149) [[3]](diffhunk://#diff-a30e3bcd92ebd10fe7a4f4d38eb2cbe3fcec38c7bd8b9b077b5a3253dd251f1aL158-R172) [[4]](diffhunk://#diff-a30e3bcd92ebd10fe7a4f4d38eb2cbe3fcec38c7bd8b9b077b5a3253dd251f1aL207-R215)
* **New Test for Skipping Empty Variables**: Added a new test case to verify that empty extra variables are skipped during encryption.