### PR TITLE
[RUN-4638] Migrate publishing from Maven Central to PackageCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
         run: |
-          if [ -z "$PKGCLD_REPO_URL" ] || [ -z "$PKGCLD_WRITE_TOKEN" ]; then
-            echo "::error::PKGCLD_REPO_URL and PKGCLD_WRITE_TOKEN must both be set to publish to PackageCloud"
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
             exit 1
           fi
           ./gradlew publishAllPublicationsToPackageCloudRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
-        run: ./gradlew publishAllPublicationsToPackageCloudRepository
+        run: |
+          if [ -z "$PKGCLD_REPO_URL" ] || [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_REPO_URL and PKGCLD_WRITE_TOKEN must both be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,29 @@ jobs:
           ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/ansible-plugin/${VERSION}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          sign_and_upload "build/libs/ansible-plugin-${VERSION}.jar" "ansible-plugin-${VERSION}.jar"
+          sign_and_upload "build/libs/ansible-plugin-${VERSION}-sources.jar" "ansible-plugin-${VERSION}-sources.jar"
+          sign_and_upload "build/libs/ansible-plugin-${VERSION}-javadoc.jar" "ansible-plugin-${VERSION}-javadoc.jar"
+          sign_and_upload "build/publications/ansible-plugin/pom-default.xml" "ansible-plugin-${VERSION}.pom"
+        env:
+          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Publish Release
     runs-on: ubuntu-latest
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -33,10 +35,7 @@ jobs:
             build/libs/ansible-plugin-${{ steps.get_version.outputs.VERSION }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'pl.allegro.tech.build.axion-release' version '1.21.2'
-  id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 group = 'org.rundeck.plugins'
@@ -158,16 +157,6 @@ jar {
     attributes 'Rundeck-Plugin-URL': 'https://github.com/rundeck-plugins/ansible-plugin'
   }
   dependsOn(copyToLib)
-}
-
-nexusPublishing {
-  packageGroup = 'org.rundeck.plugins'
-  repositories {
-    sonatype {
-      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-    }
-  }
 }
 
 apply from: "${rootDir}/gradle/publishing.gradle"

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -8,7 +8,7 @@
  */
 apply plugin: 'maven-publish'
 
-def pkgcldRepoUrl = System.getenv("PKGCLD_REPO_URL")?.trim()
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
 
 publishing {
     publications {
@@ -48,19 +48,15 @@ publishing {
         }
     }
     repositories {
-        // Only register the PackageCloud repo when its URL is configured, so plain
-        // builds/tests (which don't set PKGCLD_REPO_URL) don't fail at configuration time.
-        if (pkgcldRepoUrl) {
-            maven {
-                name = "PackageCloud"
-                url = uri(pkgcldRepoUrl)
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
-                }
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
             }
         }
     }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -5,18 +5,10 @@
  * publishDescription = 'description' (optional)
  * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
  * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
- *
- * Define project properties to sign and publish when invoking publish task:
- *
- *     ./gradlew \
- *     -PsigningKey="base64 encoded gpg key" \
- *     -PsigningPassword="password for key" \
- *     -PsonatypeUsername="sonatype token user" \
- *     -PsonatypePassword="sonatype token password" \
- *     publishToSonatype closeAndReleaseSonatypeStagingRepository
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
+
+def pkgcldRepoUrl = System.getenv("PKGCLD_REPO_URL")?.trim()
 
 publishing {
     publications {
@@ -56,31 +48,20 @@ publishing {
         }
     }
     repositories {
-        def pkgcldWriteToken = System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken")
-        if (pkgcldWriteToken) {
+        // Only register the PackageCloud repo when its URL is configured, so plain
+        // builds/tests (which don't set PKGCLD_REPO_URL) don't fail at configuration time.
+        if (pkgcldRepoUrl) {
             maven {
-                name = "PackageCloudTest"
-                url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
+                name = "PackageCloud"
+                url = uri(pkgcldRepoUrl)
                 authentication {
                     header(HttpHeaderAuthentication)
                 }
                 credentials(HttpHeaderCredentials) {
                     name = "Authorization"
-                    value = "Bearer " + pkgcldWriteToken
+                    value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
                 }
             }
         }
-    }
-}
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4638](https://pagerduty.atlassian.net/browse/RUN-4638) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Description

Migrate `ansible-plugin` publishing from Maven Central (Sonatype) to PackageCloud, applying the same design already validated on [rundeck-plugins/sshj-plugin#136](https://github.com/rundeck-plugins/sshj-plugin/pull/136) and [rundeck-plugins/http-step#60](https://github.com/rundeck-plugins/http-step/pull/60). Part of the RUN-4570 Maven Central publishing limits resolution — plugins account for the bulk of the file/release count on Maven Central, but no external project depends on them as Maven dependencies.

- Removed `nexusPublish`/`nexusPublishing` (Sonatype-specific, dead once `release.yml` stops calling `publishToSonatype`).
- Point the existing PackageCloud maven repo at the configurable `PKGCLD_REPO_URL` env var (trimmed, and guarded so plain builds/CI without the var don't fail at Gradle configuration time), replacing the hardcoded `rundeckpro-test` URL left over from an earlier test.
- Dropped GPG signing: PackageCloud's Maven endpoint rejects the checksum Gradle auto-generates for `.asc` signature files (422 Unprocessable Entity on `*.jar.asc.sha1`), and neither the OSS `rundeck` WAR nor `rundeckpro-enterprise` WAR carry `.asc` signatures on PackageCloud either — only RPM/DEB packages are signed there, natively, via the separately-published `BUILD-GPG-KEY`.
- `release.yml`: replaced the "Publish to Maven Central" step with "Publish to PackageCloud".

## Testing instructions

- Merge this PR.
- Tag a test version to trigger the release workflow (this exact flow — build, sign-free publish, checksums — was validated end-to-end on `sshj-plugin` 1.0.4: jar/pom/sources/javadoc all publish successfully to PackageCloud).
- Verify the artifact appears under `org/rundeck/plugins/ansible-plugin/<version>/` at whatever repo `PKGCLD_REPO_URL` points to.
- Verify `./gradlew build` still succeeds without `PKGCLD_REPO_URL` set (e.g. in `gradle.yml` CI) — the PackageCloud repo registration is guarded and should not affect plain builds.
